### PR TITLE
Update uk.yml

### DIFF
--- a/i18n/uk.yml
+++ b/i18n/uk.yml
@@ -55,6 +55,6 @@ easing:
 
 opensource:
   title: open source
-  translate: ^Допоможи перевести^ сайт на свою мову
+  translate: ^Допоможи перекласти^ сайт на свою мову
 
 author: Андрій Ситник


### PR DESCRIPTION
Слово "перевести" від "переводити" - не використовується в контексті пов'язаному з мовами.
Слово "перекласти" від "перекладати" - більш правильний варіант в даному випадку.
