### PR TITLE
correct "it's" to "its" in the english translation

### DIFF
--- a/i18n/en.yml
+++ b/i18n/en.yml
@@ -42,7 +42,7 @@ howtos:
     Unfortunately, they don’t support all easings and you must
     specify the desired easing function yourself (as a Bezier curve).
   css_help:
-    Select an easing function to show it’s Bezier curve notation.
+    Select an easing function to show its Bezier curve notation.
 
 easing:
   all_easings: All easings


### PR DESCRIPTION
We shouldn't be using the contraction of "it is" in this instance.