### PR TITLE
Centered "css+js" heading

### DIFF
--- a/styles/style.sass
+++ b/styles/style.sass
@@ -51,11 +51,11 @@ $easing-width: 120px + 4px
     position: absolute
     top: -12px
     right: 35px
-    width: 40px
+    width: 98%
     color: #999
     font-size: 14px
     font-weight: normal
-    text-align: right
+    text-align: center
 
 .easings.hightlight-part
   .part ul


### PR DESCRIPTION
This is how the heading of "css+jss" previously looked, floating to the right:
<img width="1037" alt="screen shot 2017-01-02 at 9 50 05 am" src="https://cloud.githubusercontent.com/assets/21118039/21584575/c8629a54-d0d2-11e6-94f9-d96489cfd110.png">



This is how the heading looks after centering:
<img width="906" alt="screen shot 2017-01-02 at 10 04 33 am" src="https://cloud.githubusercontent.com/assets/21118039/21584580/003b7162-d0d3-11e6-8489-58843146b749.png">
