### PR TITLE
Clean selection and collapse details on function change

### DIFF
--- a/src/helpers/constants.ts
+++ b/src/helpers/constants.ts
@@ -4,6 +4,7 @@ export const selectorInfo = ".info";
 export const selectorInfoChart = ".info-chart";
 export const selectorSimpleInfo = ".js-info-simple";
 export const selectorComplexInfo = ".js-info-complex";
+export const selectorDetails = ".details";
 export const selectorCode = ".details__code";
 export const selectorComplexKeyframeScale = `${selectorCode}[data-type=scale]`;
 export const selectorComplexKeyframeOpacity = `${selectorCode}[data-type=opacity]`;

--- a/src/navigation/navigation.ts
+++ b/src/navigation/navigation.ts
@@ -2,7 +2,15 @@ import { clearTransition, setFuncForCard } from "../card/card";
 import { getTransitionTime } from "../helpers/getTransitionTime";
 import { getElementPosition } from "../helpers/getElementPosition";
 import { parseStringOfFourNumbers } from "../helpers/parseStringOfFourNumbers";
-import { infoChartOffsetTopClassName, noTimingFunction, selectorInfo, selectorInfoChart } from "../helpers/constants";
+import {
+	infoChartOffsetTopClassName,
+	noTimingFunction,
+	selectorInfo,
+	selectorInfoChart,
+	selectorDetails,
+} from "../helpers/constants";
+import { forNodeList } from "../helpers/forNodeList";
+import { getElementsList } from "../helpers/getElement";
 import { setInfoFunc, setInfoName, showComplexInfo, showSimpleInfo } from "../info/info";
 import { resetOverlay, setSizeOverlay, setTransitionDurationOverlay, showOverlay } from "../overlay/overlay";
 import { hideGradient, setGradient } from "../gradient/gradient";
@@ -37,6 +45,15 @@ if (chartId) {
 window.addEventListener(
 	"hashchange",
 	() => {
+		if (window.getSelection) {
+			window.getSelection().removeAllRanges();
+		}
+		forNodeList(getElementsList(selectorDetails), (item) => {
+			if (item.hasAttribute("open")) {
+				item.removeAttribute("open");
+			}
+		});
+
 		const id = window.location.hash.slice(1);
 
 		if (id) {


### PR DESCRIPTION
![easings](https://user-images.githubusercontent.com/20732009/69120098-a7409600-0aa9-11ea-8394-2927a22ea17c.gif)

As it captured on gif the selection and expanded detail tag is kept even when the function is changed.
I don't think this behavior is expected. Otherwise feel free to close the PR.